### PR TITLE
Fix Layout and Design

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "http://DavidSedley.github.io"
+baseurl = "https://DavidSedley.github.io"
 languageCode = "en-us"
 # theme = "hyde"
 theme = "bootie-docs"


### PR DESCRIPTION
Currently, the page at https://davidsedley.github.io/ looks terrible, because github switched to https. Since the styling information was loaded via http, the download was prevented by the browser.
To fix this, the baseurl changes from http to https.